### PR TITLE
Removed legacy Accept header

### DIFF
--- a/src/TwitchHelix.php
+++ b/src/TwitchHelix.php
@@ -93,8 +93,7 @@ class TwitchHelix extends AbstractProvider
     protected function getDefaultHeaders()
     {
         return [
-            'Client-ID' => $this->clientId,
-            'Accept' => 'application/vnd.twitchtv.v5+json'
+            'Client-ID' => $this->clientId
         ];
     }
 


### PR DESCRIPTION
Removed legacy Accept: application/vnd.twitchtv.v5+json header
> For client IDs created on or after May 31, 2019, the only available version of the Legacy Twitch API is v5.  For client IDs created prior to May 31, 2019, use the Accept: application/vnd.twitchtv.v5+json header on your requests to access v5 of the Legacy Twitch API API.

https://dev.twitch.tv/docs/v5