### PR TITLE
PHP 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "league/oauth2-client": "^2.2.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^10.0.5",
         "mockery/mockery": "^1.2",
         "ext-json": "*",
         "squizlabs/php_codesniffer": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.1",
         "league/oauth2-client": "^2.2.1"
     },
     "require-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="./vendor/autoload.php">
-    <testsuites>
-        <testsuite name="OAuth2 Client Provider Test Suite">
-            <directory suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="OAuth2 Client Provider Test Suite">
+      <directory suffix=".php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/TwitchHelix.php
+++ b/src/TwitchHelix.php
@@ -37,7 +37,7 @@ class TwitchHelix extends AbstractProvider
         parent::__construct($options);
     }
 
-    protected function getConfigurableOptions()
+    protected function getConfigurableOptions(): array
     {
         return [
             'accessTokenMethod',
@@ -50,27 +50,27 @@ class TwitchHelix extends AbstractProvider
         ];
     }
 
-    public function getBaseAuthorizationUrl()
+    public function getBaseAuthorizationUrl(): string
     {
         return $this->domain . self::PATH_AUTHORIZE;
     }
 
-    public function getBaseAccessTokenUrl(array $params)
+    public function getBaseAccessTokenUrl(array $params): string
     {
         return $this->domain . self::PATH_TOKEN;
     }
 
-    public function getResourceOwnerDetailsUrl(AccessToken $token)
+    public function getResourceOwnerDetailsUrl(AccessToken $token): string
     {
         return $this->resourceDomain . self::USER_RESOURCE;
     }
 
-    public function getDefaultScopes()
+    public function getDefaultScopes(): array
     {
         return $this->scopes;
     }
 
-    protected function getScopeSeparator()
+    protected function getScopeSeparator(): string
     {
         return self::SCOPE_SEPARATOR;
     }
@@ -85,19 +85,19 @@ class TwitchHelix extends AbstractProvider
         }
     }
 
-    protected function createResourceOwner(array $response, AccessToken $token)
+    protected function createResourceOwner(array $response, AccessToken $token): TwitchHelixResourceOwner
     {
         return new TwitchHelixResourceOwner($response);
     }
 
-    protected function getDefaultHeaders()
+    protected function getDefaultHeaders(): array
     {
         return [
             'Client-ID' => $this->clientId
         ];
     }
 
-    protected function getAuthorizationHeaders($token = null)
+    protected function getAuthorizationHeaders($token = null): array
     {
         if ($token === null) {
             return [];

--- a/src/TwitchHelix.php
+++ b/src/TwitchHelix.php
@@ -75,7 +75,7 @@ class TwitchHelix extends AbstractProvider
         return self::SCOPE_SEPARATOR;
     }
 
-    protected function checkResponse(ResponseInterface $response, $data)
+    protected function checkResponse(ResponseInterface $response, $data): void
     {
         if (!empty($data[$this->responseError])) {
             $error = $data[$this->responseError];

--- a/src/TwitchHelixResourceOwner.php
+++ b/src/TwitchHelixResourceOwner.php
@@ -40,7 +40,7 @@ class TwitchHelixResourceOwner implements ResourceOwnerInterface
      *
      * @return string
      */
-    public function getLogin()
+    public function getLogin(): string
     {
         return $this->getValueByKey($this->response, 'login');
     }
@@ -50,7 +50,7 @@ class TwitchHelixResourceOwner implements ResourceOwnerInterface
      *
      * @return string
      */
-    public function getDisplayName()
+    public function getDisplayName(): string
     {
         return $this->getValueByKey($this->response, 'display_name');
     }
@@ -60,7 +60,7 @@ class TwitchHelixResourceOwner implements ResourceOwnerInterface
      *
      * @return string
      */
-    public function getBroadcasterType()
+    public function getBroadcasterType(): string
     {
         return $this->getValueByKey($this->response, 'broadcaster_type');
     }
@@ -70,7 +70,7 @@ class TwitchHelixResourceOwner implements ResourceOwnerInterface
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->getValueByKey($this->response, 'description');
     }
@@ -80,7 +80,7 @@ class TwitchHelixResourceOwner implements ResourceOwnerInterface
      *
      * @return string
      */
-    public function getProfileImageUrl()
+    public function getProfileImageUrl(): string
     {
         return $this->getValueByKey($this->response, 'profile_image_url');
     }
@@ -90,7 +90,7 @@ class TwitchHelixResourceOwner implements ResourceOwnerInterface
      *
      * @return string
      */
-    public function getOfflineImageUrl()
+    public function getOfflineImageUrl(): string
     {
         return $this->getValueByKey($this->response, 'offline_image_url');
     }
@@ -100,7 +100,7 @@ class TwitchHelixResourceOwner implements ResourceOwnerInterface
      *
      * @return int
      */
-    public function getViewCount()
+    public function getViewCount(): int
     {
         return (int) $this->getValueByKey($this->response, 'view_count');
     }
@@ -110,7 +110,7 @@ class TwitchHelixResourceOwner implements ResourceOwnerInterface
      *
      * @return string
      */
-    public function getEmail()
+    public function getEmail(): string
     {
         return $this->getValueByKey($this->response, 'email');
     }
@@ -120,7 +120,7 @@ class TwitchHelixResourceOwner implements ResourceOwnerInterface
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->getValueByKey($this->response, 'type');
     }
@@ -130,7 +130,7 @@ class TwitchHelixResourceOwner implements ResourceOwnerInterface
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->response;
     }

--- a/src/TwitchHelixResourceOwner.php
+++ b/src/TwitchHelixResourceOwner.php
@@ -30,7 +30,7 @@ class TwitchHelixResourceOwner implements ResourceOwnerInterface
      *
      * @return int
      */
-    public function getId()
+    public function getId(): int
     {
         return (int) $this->getValueByKey($this->response, 'id');
     }

--- a/tests/TwitchTest.php
+++ b/tests/TwitchTest.php
@@ -15,7 +15,7 @@ class TwitchTest extends TestCase
 
     protected $provider;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->provider = new TwitchHelix([
             'clientId' => 'mock_client_id',
@@ -24,7 +24,7 @@ class TwitchTest extends TestCase
         ]);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
         parent::tearDown();

--- a/tests/TwitchTest.php
+++ b/tests/TwitchTest.php
@@ -6,6 +6,7 @@ use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Tool\QueryBuilderTrait;
 use PHPUnit\Framework\TestCase;
 use Mockery as m;
+use Psr\Http\Message\StreamInterface;
 use Vertisan\OAuth2\Client\Provider\TwitchHelix;
 use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\ClientInterface;
@@ -81,15 +82,22 @@ class TwitchTest extends TestCase
      */
     public function testGetAccessToken()
     {
-        $response = m::mock(ResponseInterface::class);
-        $response->shouldReceive('getBody')
+        $stream = m::mock(StreamInterface::class);
+        $stream->shouldReceive('__toString')
             ->andReturn(json_encode([
                 'access_token' => 'mock_access_token',
                 'token_type' => 'bearer',
                 'expires_in' => 1000,
                 'refresh_token' => 'mock_refresh_token',
-            ]))
-        ;
+            ]));
+
+        $response = m::mock(ResponseInterface::class);
+        $response->shouldReceive('getBody')
+            ->andReturn($stream);
+
+        $response = m::mock(ResponseInterface::class);
+        $response->shouldReceive('getBody')
+            ->andReturn($stream);
 
         $response->shouldReceive('getHeader')
             ->andReturn(['content-type' => 'json']);

--- a/tests/TwitchTest.php
+++ b/tests/TwitchTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Vertisan\OAuth2\Client\Test\Provider;
 
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Tool\QueryBuilderTrait;
 use PHPUnit\Framework\TestCase;
@@ -49,7 +50,7 @@ class TwitchTest extends TestCase
         $options = ['scope' => [uniqid('', true), uniqid('', true)]];
         $query = ['scope' => implode(TwitchHelix::SCOPE_SEPARATOR, $options['scope'])];
         $url = $this->provider->getAuthorizationUrl($options);
-        $this->assertContains($this->buildQueryString($query), $url);
+        $this->assertStringContainsString($this->buildQueryString($query), $url);
     }
 
     public function testGetAuthorizationUrl()
@@ -75,6 +76,9 @@ class TwitchTest extends TestCase
         $this->assertEquals(TwitchHelix::USER_RESOURCE, $uri['path']);
     }
 
+    /**
+     * @throws IdentityProviderException
+     */
     public function testGetAccessToken()
     {
         $response = m::mock(ResponseInterface::class);


### PR DESCRIPTION
Update code to compatible with PHP 8.1

 I have change min version to PHP 7.1 because void return type require PHP 7.1
I have update PHPUnit for new php version
I have update the test to the new php unit version
I have add return type on function
I have create streaming on testGetAccessToken because new php unit require a stram on body and no string.

Thank to reading me.
If you have a question you can ask me !